### PR TITLE
bump to mongo 3.4.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dokku mongo (beta) [![Build Status](https://img.shields.io/travis/dokku/dokku-mongo.svg?branch=master "Build Status")](https://travis-ci.org/dokku/dokku-mongo) [![IRC Network](https://img.shields.io/badge/irc-freenode-blue.svg "IRC Freenode")](https://webchat.freenode.net/?channels=dokku)
 
-Official mongo plugin for dokku. Currently defaults to installing [mongo 3.4.9](https://hub.docker.com/_/mongo/).
+Official mongo plugin for dokku. Currently defaults to installing [mongo 3.4.10](https://hub.docker.com/_/mongo/).
 
 ## requirements
 

--- a/config
+++ b/config
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 export MONGO_IMAGE=${MONGO_IMAGE:="mongo"}
-export MONGO_IMAGE_VERSION=${MONGO_IMAGE_VERSION:="3.4.9"}
+export MONGO_IMAGE_VERSION=${MONGO_IMAGE_VERSION:="3.4.10"}
 export MONGO_ROOT=${MONGO_ROOT:="/var/lib/dokku/services/mongo"}
 
 export PLUGIN_COMMAND_PREFIX="mongo"

--- a/tests/bin/docker
+++ b/tests/bin/docker
@@ -19,7 +19,7 @@ case "$1" in
     echo "dokkupaas/docker-grafana-graphite    3.0.1               75dcd48a5eef        2 days ago          936.4 MB"
     echo "mariadb                              10.1.16             f2485761e714        2 days ago          302.2 MB"
     echo "memcached                            1.4.31              8a05b51f8876        2 days ago          132.4 MB"
-    echo "mongo                                3.4.9               12eadb136159        2 days ago          291.1 MB"
+    echo "mongo                                3.4.10              12eadb136159        2 days ago          291.1 MB"
     echo "mysql                                5.7.12              57d56ac47bed        2 days ago          321.3 MB"
     echo "nats                                 0.9.4               9216d5a4eec8        2 days ago          109.3 MB"
     echo "postgres                             9.5.4               6412eb70175e        2 days ago          265.7 MB"

--- a/tests/service_list.bats
+++ b/tests/service_list.bats
@@ -11,20 +11,20 @@ teardown() {
 
 @test "($PLUGIN_COMMAND_PREFIX:list) with no exposed ports, no linked apps" {
   run dokku "$PLUGIN_COMMAND_PREFIX:list"
-  assert_contains "${lines[*]}" "l     mongo:3.4.9  running  -              -"
+  assert_contains "${lines[*]}" "l     mongo:3.4.10  running  -              -"
 }
 
 @test "($PLUGIN_COMMAND_PREFIX:list) with exposed ports" {
   dokku "$PLUGIN_COMMAND_PREFIX:expose" l 4242 4243 4244 4245
   run dokku "$PLUGIN_COMMAND_PREFIX:list"
-  assert_contains "${lines[*]}" "l     mongo:3.4.9  running  27017->4242 27018->4243 27019->4244 28017->4245   -"
+  assert_contains "${lines[*]}" "l     mongo:3.4.10  running  27017->4242 27018->4243 27019->4244 28017->4245   -"
 }
 
 @test "($PLUGIN_COMMAND_PREFIX:list) with linked app" {
   dokku apps:create my_app
   dokku "$PLUGIN_COMMAND_PREFIX:link" l my_app
   run dokku "$PLUGIN_COMMAND_PREFIX:list"
-  assert_contains "${lines[*]}" "l     mongo:3.4.9  running  -              my_app"
+  assert_contains "${lines[*]}" "l     mongo:3.4.10  running  -              my_app"
   dokku --force apps:destroy my_app
 }
 


### PR DESCRIPTION
I'm using your repo for my dokku mongo plugin. I just want to bump it 3.4.10 since that's the last stable.